### PR TITLE
fix: correct promise awaiting logic in writeCommandsToConnection to support concurrency

### DIFF
--- a/src/lib/redis-instance.ts
+++ b/src/lib/redis-instance.ts
@@ -234,6 +234,8 @@ export class RedisInstance {
 
     const chunks: Array<string | Uint8Array> = [];
 
+    const currentBatchPromises: Promise<RedisResponse>[] = [];
+
     for (const command of commands) {
       const { promise, resolve, reject } =
         Promise.withResolvers<RedisResponse>();
@@ -243,6 +245,8 @@ export class RedisInstance {
         resolve,
         reject,
       });
+
+      currentBatchPromises.push(promise);
 
       const payload = encodeCommand(
         command.map((arg) => (arg instanceof Uint8Array ? arg : String(arg))),
@@ -257,7 +261,7 @@ export class RedisInstance {
       );
     }
 
-    return Promise.all(this.promiseQueue.map((p) => p.promise));
+    return Promise.all(currentBatchPromises);
   }
 
   private async startMessageListener(connection: ConnectionInstance) {


### PR DESCRIPTION
修复了 writeCommandsToConnection 中的并发 Bug。原代码错误地等待了全局的 promiseQueue，而不是仅等待当前批次发送的命令。

问题原因： 当多个命令并发发送时（例如通过 Promise.all），每个调用都会等待全局队列中所有的 Promise。这导致了竞态条件：由于 result.at(-1) 是作用于一个被污染的（包含他人结果的）共享数组，某个请求可能会错误地返回后续并发请求的结果。

修复方案： 引入了局部数组 currentBatchPromises，用于隔离并追踪仅在当前执行作用域内创建的 Promise。这确保了每个 send 调用只解析其对应的 Redis 响应，从而实现了安全可靠的 Pipeline 并发。