### PR TITLE
rename CreateRedisOptions to RedisOptions

### DIFF
--- a/.tegami/export-types.md
+++ b/.tegami/export-types.md
@@ -5,3 +5,5 @@ packages:
 ---
 
 ### Export option and response types from the package entry
+
+`CreateRedisOptions`, `RedisResponse`, and the other public types are now importable from `redis-on-workers` instead of living only inside the package.

--- a/.tegami/export-types.md
+++ b/.tegami/export-types.md
@@ -6,4 +6,4 @@ packages:
 
 ### Export option and response types from the package entry
 
-`CreateRedisOptions`, `RedisResponse`, and the other public types are now importable from `redis-on-workers` instead of living only inside the package.
+`RedisOptions`, `RedisResponse`, and the other public types are now importable from `redis-on-workers` instead of living only inside the package.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ npm install @arrowood.dev/socket
 
 ## API
 
-### `createRedis(options: CreateRedisOptions | string): Redis`
+### `createRedis(options: RedisOptions | string): Redis`
 
 Create a Redis client. It connects when you send the first command.
 
@@ -72,7 +72,7 @@ Create a Redis client. It connects when you send the first command.
 - `redis.sendRaw(...command)`: send a command, keep bulk strings as `Uint8Array`.
 - `redis.close()`: close the connection. The next `send` reconnects.
 
-### `CreateRedisOptions`
+### `RedisOptions`
 
 - `url` (string): The URL of the Redis server.
 - `tls` (boolean): Whether to use TLS. Defaults to true for `rediss:` URLs.

--- a/src/create-redis.ts
+++ b/src/create-redis.ts
@@ -1,7 +1,7 @@
 import { Redis } from "~/lib/redis";
-import type { CreateRedisOptions } from "~/type";
+import type { RedisOptions } from "~/type";
 
 /** Create a client from a redis:// URL or an options object; connects lazily. */
-export function createRedis(options: CreateRedisOptions | string) {
+export function createRedis(options: RedisOptions | string) {
   return new Redis(typeof options === "string" ? { url: options } : options);
 }

--- a/src/lib/connection.ts
+++ b/src/lib/connection.ts
@@ -1,6 +1,6 @@
 import type { connect as nodeConnect } from "@arrowood.dev/socket";
 import type { connect } from "cloudflare:sockets";
-import type { CreateRedisOptions, RedisConnectConfig, RedisResponse } from "~/type";
+import type { RedisOptions, RedisConnectConfig, RedisResponse } from "~/type";
 import { decodeResp, type RespReader } from "~/lib/resp";
 import { getConnectFn } from "~/lib/utils/get-connect-fn";
 
@@ -31,7 +31,7 @@ export class Connection {
 
   static async open(
     config: RedisConnectConfig,
-    options: Pick<CreateRedisOptions, "connectFn" | "logger">,
+    options: Pick<RedisOptions, "connectFn" | "logger">,
   ) {
     const connectFn = await getConnectFn(options.connectFn);
 

--- a/src/lib/redis.ts
+++ b/src/lib/redis.ts
@@ -1,11 +1,11 @@
-import type { Command, CreateRedisOptions, RedisConnectConfig, RedisResponse } from "~/type";
+import type { Command, RedisOptions, RedisConnectConfig, RedisResponse } from "~/type";
 import { Connection } from "~/lib/connection";
 import { encodeCommand } from "~/lib/utils/encode-command";
 import { stringifyResult } from "~/lib/utils/stringify-result";
 
 const connectionClosedError = new Error("Redis connection closed");
 
-function parseConnectConfig(options: CreateRedisOptions): RedisConnectConfig {
+function parseConnectConfig(options: RedisOptions): RedisConnectConfig {
   if ("url" in options) {
     const { hostname, port, username, password, pathname, protocol } = new URL(options.url);
 
@@ -46,7 +46,7 @@ export class Redis {
   private connection?: Promise<Connection>;
   private pending: PromiseWithResolvers<RedisResponse>[] = [];
 
-  constructor(private options: CreateRedisOptions) {
+  constructor(private options: RedisOptions) {
     this.config = parseConnectConfig(options);
   }
 

--- a/src/lib/utils/get-connect-fn.ts
+++ b/src/lib/utils/get-connect-fn.ts
@@ -1,6 +1,6 @@
-import type { CreateRedisOptions } from "~/type";
+import type { RedisOptions } from "~/type";
 
-export async function getConnectFn(fn?: CreateRedisOptions["connectFn"]) {
+export async function getConnectFn(fn?: RedisOptions["connectFn"]) {
   if (fn) return fn;
 
   try {

--- a/src/type.ts
+++ b/src/type.ts
@@ -13,7 +13,7 @@ export type StringifyRedisResponse =
   | string
   | StringifyRedisResponse[];
 
-/** The connection parameters resolved from `CreateRedisOptions`. */
+/** The connection parameters resolved from `RedisOptions`. */
 export interface RedisConnectConfig {
   hostname: string;
   port: number;
@@ -44,4 +44,4 @@ export type RedisConnectionOptions =
       database?: string;
     };
 
-export type CreateRedisOptions = BaseRedisOptions & RedisConnectionOptions;
+export type RedisOptions = BaseRedisOptions & RedisConnectionOptions;


### PR DESCRIPTION
## Why
The 0.5.0 changelog entry had a heading with no body, and `CreateRedisOptions` no longer matches the `Redis` / `createRedis` naming.

## What
Rename `CreateRedisOptions` to `RedisOptions` across the package and fill in the export-types changelog body. Both land before 0.5.0 publishes, so nothing breaks.